### PR TITLE
add proper thread termination / syncronization

### DIFF
--- a/win32_blandwidth.c
+++ b/win32_blandwidth.c
@@ -247,9 +247,9 @@ mainCRTStartup(void)
     // an actually good way to handle termination.
     //
 
-    for (u32 ThreadIndex = 0;
-            ThreadIndex < MaxThreadCount;
-            ++ThreadIndex)
+    for(u32 ThreadIndex = 0;
+        ThreadIndex < MaxThreadCount;
+        ++ThreadIndex)
     {
         // Send special termination packet (numBytes, key, OVERLAPPED pointer all set to NULL)
         PostQueuedCompletionStatus(Win32Context.Queues.Dispatch, 0, 0, NULL);
@@ -259,16 +259,16 @@ mainCRTStartup(void)
     // NOTE: wait for all threads to terminate
     //
 
-    for (u32 ThreadIndex = 0;
-            ThreadIndex < MaxThreadCount;
-            ++ThreadIndex)
+    for(u32 ThreadIndex = 0;
+        ThreadIndex < MaxThreadCount;
+        ++ThreadIndex)
     {
-            Statusf("Waiting for thread %d (thread id %d)", (int)ThreadIndex, (int)ThreadIDs[ThreadIndex]);
-            if (WaitForSingleObject(ThreadHandles[ThreadIndex], INFINITE) != WAIT_OBJECT_0)
-            {
-                    Statusf("ERROR: Wait failed");
-                    ExitProcess(1);
-            }
+        Statusf("Waiting for thread %d (thread id %d)", (int)ThreadIndex, (int)ThreadIDs[ThreadIndex]);
+        if (WaitForSingleObject(ThreadHandles[ThreadIndex], INFINITE) != WAIT_OBJECT_0)
+        {
+            Statusf("ERROR: Wait failed");
+            ExitProcess(1);
+        }
     }
     
     //


### PR DESCRIPTION
This commit adds proper thread synchronization on termination to the program. This is to remove a hack / comment in the code that I disagree with: "The semantic analysis in modern compilers is actively awful.  I had to do while() here for (;;) because if I did for(;;), it errored out because the return(0) was unreachable, and if I got rid of the return(0), it errored out because the function didn't return a value."

IMO it makes perfect sense that functions are supposed to have a proper termination path other than being killed while still doing work (and thus I think the semantic analysis is right). In many programs this approach of unsynchronized termination (even when terminating with ExitProcess()??) would produce segfaults on termination, when the running workers are trying to access data structures that are deconstructed when the main thread is shutting down. A simple example would be stdio handles being closed when returning from main(), resulting in a segfault if any other thread wants to print something to stdout.

This commit changes the main thread to send termination messages to the worker threads, and to wait for termination of the workers. It also adds a proper termination path to the worker threads and removes the hack that is writing `while (Queues)` which is now no longer necessary.