### PR TITLE
Use _mm256_xor_ps instead of _mm256_xor_si256 for AVX compatibility

### DIFF
--- a/x64_blandwidth.c
+++ b/x64_blandwidth.c
@@ -5,6 +5,9 @@
    $Creator: Casey Muratori $
    ======================================================================== */
 
+// NOTE(keeba): This is used instead of _mm256_xor_si256 because _mm256_xor_ps does not require AVX2.
+#define Xor256(A, B) _mm256_castps_si256(_mm256_xor_ps(_mm256_castsi256_ps(A), _mm256_castsi256_ps(B)))
+
 function void
 X64Read128(memory_operation *Op)
 {
@@ -217,11 +220,11 @@ X64Read256(memory_operation *Op)
         __m256i L1 = _mm256_loadu_si256(Source + 1);
         __m256i L2 = _mm256_loadu_si256(Source + 2);
         __m256i L3 = _mm256_loadu_si256(Source + 3);
-        
-        V0 = _mm256_xor_si256(V0, L0);
-        V1 = _mm256_xor_si256(V1, L1);
-        V2 = _mm256_xor_si256(V2, L2);
-        V3 = _mm256_xor_si256(V3, L3);
+
+        V0 = Xor256(V0, L0);
+        V1 = Xor256(V1, L1);
+        V2 = Xor256(V2, L2);
+        V3 = Xor256(V3, L3);
 
         SourceOffset = (SourceOffset + Pattern.SourceStride) & Pattern.SourceMask;
     }
@@ -254,10 +257,10 @@ X64Write256(memory_operation *Op)
 
         __m256i *Dest = (__m256i *)(Pattern.Dest + DestOffset);
 
-        V0 = _mm256_xor_si256(V0, V1);
-        V1 = _mm256_xor_si256(V1, V2);
-        V2 = _mm256_xor_si256(V2, V3);
-        V3 = _mm256_xor_si256(V3, V0);
+        V0 = Xor256(V0, V1);
+        V1 = Xor256(V1, V2);
+        V2 = Xor256(V2, V3);
+        V3 = Xor256(V3, V0);
         
         _mm256_storeu_si256(Dest + 0, V0);
         _mm256_storeu_si256(Dest + 1, V1);
@@ -302,10 +305,10 @@ X64ReadWrite256(memory_operation *Op)
         __m256i L2 = _mm256_loadu_si256(Source + 2);
         __m256i L3 = _mm256_loadu_si256(Source + 3);
 
-        V0 = _mm256_xor_si256(V0, L0);
-        V1 = _mm256_xor_si256(V1, L1);
-        V2 = _mm256_xor_si256(V2, L2);
-        V3 = _mm256_xor_si256(V3, L3);
+        V0 = Xor256(V0, L0);
+        V1 = Xor256(V1, L1);
+        V2 = Xor256(V2, L2);
+        V3 = Xor256(V3, L3);
         
         _mm256_storeu_si256(Dest + 0, V0);
         _mm256_storeu_si256(Dest + 1, V1);


### PR DESCRIPTION
Currently, we detect AVX and choose to execute the X64*256 functions whenever we find that we support it. However, processors that support AVX, but not AVX2, will straight up crash because they do not support the `_mm256_xor_si256` instruction.

We could keep the current functions, and only run them if we detect AVX2:

``` c++
__cpuidex(CID, 1, 0);
b32 AVXIsSupported = CID[2] & (1 << 28);
__cpuidex(CID, 7, 0);
b32 AVX2IsSupported = CID[1] & (1 << 5); // NOTE(keeba): We need AVX2 for _mm256_xor_si256
if(AVXIsSupported && AVX2IsSupported) // ...
```

But that's pretty silly, since AVX supports _mm256_xor_ps fine, so we just use that instruction instead.

There is still some weirdness going on with these instructions; namely, according to https://software.intel.com/sites/landingpage/IntrinsicsGuide/ , on Broadwell and Haswell machines, `_mm256_xor_ps` has a throughput of 1.0 whereas `_mm256_xor_si256` has a throughput of 0.33. I'm not sure why that is, given that both instructions are doing the same exact work! Maybe that means that the machines that only support AVX will XOR at a throughput of 1, and the ones that support AVX2 will XOR at a throughput of 0.33, and the intrinsics guide is only showing a conservative estimate or something?

In any case, the current code is obviously memory-bound, so this should not be an issue.