### PR TITLE
Add linux port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Blandwidth r1
-Blandwidth is a compact memory bandwidth tester for x64 CPUs running Windows.  It was developed during creation of the [Star Code Galaxy](https://starcodegalaxy.com) programming course because publicly available per-core bandwidth measurements seemed scarce.  It is difficult to tell students to learn about their processor's per-core memory bandwidth numbers when nobody seems to publish them!
+Blandwidth is a compact memory bandwidth tester for x64 CPUs running Windows or Linux.  It was developed during creation of the [Star Code Galaxy](https://starcodegalaxy.com) programming course because publicly available per-core bandwidth measurements seemed scarce.  It is difficult to tell students to learn about their processor's per-core memory bandwidth numbers when nobody seems to publish them!
 
 Blandwidth is designed to determine the sustainable real bandwidth from the processor to L1, L2, L3, and main memory during single thread and multiple thread workloads.  It is meant to produce numbers programmers can use to create realistic estimates of how much read, write, or read-write bandwidth their algorithms can expect for each specific processor and number of concurrent threads.
 
 # Building
+
+## Windows
 
 To build Blandwidth, install either Visual Studio or CLANG, cd to the blandwidth directory and run:
 
@@ -15,6 +17,16 @@ Note that Blandwidth on Windows has no prerequisites and no dependencies other t
 
 If your system supports llvm-mca, the build.bat file will run it and write into the build directory a cycle analysis of the memory routines.  This can be useful for ensuring that your version of the C compiler is generating efficient memory test routines.
 
+## Linux
+
+To build Blandwidth, install CLANG, cd to the blandwidth directory, and run:
+
+``` bash
+$ ./linux_build.sh
+```
+
+This produces debug and release builds as well as LLVM MCA data (if you installation includes `llvm-mca`) in the `build/` directory.
+
 # Usage
 
 To run Blandwidth, run a release executable and pipe the output to the file where measurements should be stored, eg.: 
@@ -23,8 +35,14 @@ To run Blandwidth, run a release executable and pipe the output to the file wher
 build\blandwidth_release_msvc.exe > intel_core_i9_test.csv
 ```
 
+On Linux, this would be:
+
+``` bash
+$ build/blandwidth_release > intel_core_i9_test.csv
+```
+
 During testing, it will write summary messages to stderr which you can use to track its progress.  Once complete, it will write a CSV to stdout with the statistics gathered for each test.
 
 # Limitations
 
-As of r1, Blandwidth does not test CPU core patterns, so it does not properly discover all interesing memory bandwidth differences.  As time permits, in future versions it would be nice to use core-locked threads and test different distribution patterns to see which patterns produce the best and worst bandwidth on NUMA architectures.
+As of r1, Blandwidth does not test CPU core patterns, so it does not properly discover all interesting memory bandwidth differences.  As time permits, in future versions it would be nice to use core-locked threads and test different distribution patterns to see which patterns produce the best and worst bandwidth on NUMA architectures.

--- a/blandwidth.c
+++ b/blandwidth.c
@@ -51,10 +51,10 @@ AllocateAndFill(u64 Size)
     return(Result);
 }
     
-function time
-Subtract(time A, time B)
+function timestamp
+Subtract(timestamp A, timestamp B)
 {
-    time Result;
+    timestamp Result;
     
     Result.Clock = A.Clock - B.Clock;
     Result.Counter = A.Counter - B.Counter;
@@ -62,10 +62,10 @@ Subtract(time A, time B)
     return(Result);
 }
 
-function time
+function timestamp
 Average(time_stat A)
 {
-    time Result = A.Sum;
+    timestamp Result = A.Sum;
 
     if(A.Count)
     {
@@ -77,7 +77,7 @@ Average(time_stat A)
 }
 
 function void
-Include(time_stat *Stat, time T)
+Include(time_stat *Stat, timestamp T)
 {
     if(Stat->Count)
     {
@@ -98,7 +98,7 @@ Include(time_stat *Stat, time T)
 }
 
 function u64
-GetNanoseconds(time BaseHz, u64 A)
+GetNanoseconds(timestamp BaseHz, u64 A)
 {
     u64 NSPerS = 1000ULL * 1000 * 1000;
     u64 Result = (NSPerS*A)/BaseHz.Counter;
@@ -106,7 +106,7 @@ GetNanoseconds(time BaseHz, u64 A)
 }
 
 function u64
-GetBandwidthAs(time BaseHz, memory_test_results *Res, u64 Unit)
+GetBandwidthAs(timestamp BaseHz, memory_test_results *Res, u64 Unit)
 {
     u64 Hz = BaseHz.Counter;
     u64 Measure = Res->Total.Min.Counter;
@@ -123,7 +123,7 @@ GetBandwidthAs(time BaseHz, memory_test_results *Res, u64 Unit)
 }
 
 function u64
-GetBandwidth(time BaseHz, memory_test_results *Res)
+GetBandwidth(timestamp BaseHz, memory_test_results *Res)
 {
     u64 Result = GetBandwidthAs(BaseHz, Res, 1);
     return(Result);
@@ -136,7 +136,7 @@ TimeOperation(context *Context, u32 OpCount, memory_operation *Operations, time_
     u64 CyclesSpentOnNewMin = 0;
     while(CyclesSpentOnNewMin < MaxCyclesToSpend)
     {
-        time Now;
+        timestamp Now;
         TIME_OPEN(Now);
         u64 StartGate = (Now.Counter + Context->BaseHz.Counter)/1000;
         for(u32 OpIndex = 0;
@@ -154,16 +154,16 @@ TimeOperation(context *Context, u32 OpCount, memory_operation *Operations, time_
             ++ThreadIndex)
         {
             memory_operation *ResultOp = ReceiveWorkResult(Context);
-            time ThreadTime = Subtract(ResultOp->EndStamp, ResultOp->StartStamp);
+            timestamp ThreadTime = Subtract(ResultOp->EndStamp, ResultOp->StartStamp);
             Include(ThreadStat, ThreadTime);
             Include(&ThisRun, ResultOp->EndStamp);
             Include(&ThisRun, ResultOp->StartStamp);
         }
         
-        time TotalTime = Subtract(ThisRun.Max, ThisRun.Min);
+        timestamp TotalTime = Subtract(ThisRun.Max, ThisRun.Min);
         CyclesSpentOnNewMin += TotalTime.Clock;
         
-        time PrevMin = TotalStat->Min;
+        timestamp PrevMin = TotalStat->Min;
         Include(TotalStat, TotalTime);
         if((TotalStat->Min.Clock != PrevMin.Clock) ||
            (TotalStat->Min.Counter != PrevMin.Counter))
@@ -270,7 +270,7 @@ Main(context *Context)
                     ++PrintSizePower;
                 }
                 
-                wsprintf(Results->Name, "%s %Iu%s/%ut", Context->Handlers[HandlerIndex].Name, PrintSize, PrintSizeTable[PrintSizePower], ThreadCount);
+                Stringf(Results->Name, "%s %Iu%s/%ut", Context->Handlers[HandlerIndex].Name, PrintSize, PrintSizeTable[PrintSizePower], ThreadCount);
                 
                 Results->TotalSize = 0;
                 for(u32 ThreadIndex = 0;
@@ -335,8 +335,8 @@ Main(context *Context)
         memory_test_results *Result = TestResults + ResultIndex;
         if(Result->Total.Count)
         {
-            time TotalAvg = Average(Result->Total);
-            time ThreadAvg = Average(Result->Thread);
+            timestamp TotalAvg = Average(Result->Total);
+            timestamp ThreadAvg = Average(Result->Thread);
             
             u64 MinTotalNS = GetNanoseconds(Context->BaseHz, Result->Total.Min.Counter);
             u64 MaxTotalNS = GetNanoseconds(Context->BaseHz, Result->Total.Max.Counter);

--- a/blandwidth.h
+++ b/blandwidth.h
@@ -59,7 +59,7 @@
 #ifdef __clang__
 #define function_avx2 static __attribute__ ((__target__("avx2")))
 #define function_avx512 static __attribute__ ((__target__("avx512f")))
-#define CTAssert(TestExpression) // TODO(casey): How do I get a static assert in C in CLANG?
+#define CTAssert(TestExpression) _Static_assert(TestExpression, "Expression not true: (" #TestExpression ")")
 #else
 #define function_avx2 static
 #define function_avx512 static
@@ -75,14 +75,14 @@
 typedef unsigned char u8;
 typedef unsigned int u32;
 typedef unsigned long long u64;
-typedef unsigned long long s64;
+typedef long long s64;
 typedef u32 b32;
 
-typedef struct time
+typedef struct timestamp
 {
     u64 Clock;
     u64 Counter;
-} time;
+} timestamp;
 
 typedef struct memory_operation memory_operation;
 typedef void memory_operation_handler(memory_operation *);
@@ -116,8 +116,8 @@ struct memory_operation
     // NOTE(casey): Output
     //
     
-    time StartStamp;
-    time EndStamp;
+    timestamp StartStamp;
+    timestamp EndStamp;
     
     // NOTE(casey): Because threads write back into their operations, care must be taken to ensure memory_operation
     // structures exactly fill cache lines.
@@ -127,9 +127,9 @@ CTAssert(SizeOf(memory_operation) == 128);
 
 typedef struct time_stat
 {
-    time Min;
-    time Max;
-    time Sum;
+    timestamp Min;
+    timestamp Max;
+    timestamp Sum;
     u32 Count;
 } time_stat;
 
@@ -154,7 +154,7 @@ typedef struct handler_table_entry
 
 typedef struct context
 {
-    time BaseHz;
+    timestamp BaseHz;
     u32 MaxThreadCount;
     
     u32 HandlerCount;
@@ -169,4 +169,5 @@ function void DispatchWork(context *Context, u32 OpCount, memory_operation *Ops)
 function memory_operation *ReceiveWorkResult(context *Context);
 function void Statusf(char const *Format, ...);
 function void Dataf(char const *Format, ...);
+function u32 Stringf(char *Buffer, char const *Format, ...);
 function void *AllocateAndClear(u64 Size);

--- a/linux_blandwidth.c
+++ b/linux_blandwidth.c
@@ -1,0 +1,328 @@
+#ifndef __AVX__
+#define __AVX__
+#endif
+#ifndef __AVX2__
+#define __AVX2__
+#endif
+#ifndef __AVX512F__
+#define __AVX512F__
+#endif
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <cpuid.h>
+#include <immintrin.h>
+#include <sched.h>
+#include <semaphore.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/sysinfo.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "blandwidth.h"
+
+#define TIME_OPEN(stamp)                                                  \
+  ({                                                                      \
+    struct timespec _a;                                                   \
+    clock_gettime(CLOCK_MONOTONIC, &_a);                                  \
+    (stamp).Counter = ((u64)_a.tv_sec * 1000000000ull) + (u64)_a.tv_nsec; \
+    (stamp).Clock = __rdtsc();                                            \
+  })
+
+#define TIME_CLOSE(stamp)                                                 \
+  ({                                                                      \
+    (stamp).Clock = __rdtsc();                                            \
+    struct timespec _a;                                                   \
+    clock_gettime(CLOCK_MONOTONIC, &_a);                                  \
+    (stamp).Counter = ((u64)_a.tv_sec * 1000000000ull) + (u64)_a.tv_nsec; \
+  })
+
+#include "blandwidth.c"
+#include "x64_blandwidth.c"
+
+typedef struct work_node {
+  union {
+    struct work_node* Next;
+    struct work_node* NextFree;
+  };
+  memory_operation* Op;
+} work_node;
+
+typedef struct {
+  sem_t DispatchSem;
+  sem_t ResultSem;
+  work_node* DispatchHead;
+  work_node* ResultHead;
+  work_node* FirstFree;
+} linux_queues;
+
+typedef struct {
+  context Context;
+  linux_queues Queues;
+} linux_context;
+
+// NOTE(btolsch): DispatchWork and ReceiveWorkResult are single-threaded so these don't need to be
+// thread-safe.
+#define FREE_LIST_ALLOC(Head) \
+  Head;                       \
+  Head = (Head)->NextFree;
+#define FREE_LIST_FREE(Head, Node) \
+  (Node)->NextFree = Head;         \
+  Head = Node;
+
+function void
+EnqueueWork(work_node** Head, work_node* Node) {
+  work_node* CurrentHead = *Head;
+  work_node* TempHead = 0;
+  Node->Next = CurrentHead;
+  while ((TempHead = __sync_val_compare_and_swap(Head, CurrentHead, Node)) != CurrentHead) {
+    CurrentHead = TempHead;
+    Node->Next = CurrentHead;
+  }
+}
+
+function work_node*
+DequeueWork(work_node** Head) {
+  work_node* CurrentHead = *Head;
+  work_node* Result = 0;
+  while (CurrentHead && !Result) {
+    work_node* CurrentNext = CurrentHead->Next;
+    work_node* TempHead = 0;
+    if ((TempHead = __sync_val_compare_and_swap(Head, CurrentHead, CurrentNext)) == CurrentHead) {
+      Result = CurrentHead;
+    }
+    CurrentHead = TempHead;
+  }
+  return Result;
+}
+
+function void
+DispatchWork(context* Context, u32 OpCount, memory_operation* Ops) {
+  linux_context* LinuxContext = (linux_context*)Context;
+  for (u32 OpIndex = 0; OpIndex < OpCount; ++OpIndex) {
+    work_node* Work = FREE_LIST_ALLOC(LinuxContext->Queues.FirstFree);
+    Work->Op = Ops + OpIndex;
+    EnqueueWork(&LinuxContext->Queues.DispatchHead, Work);
+    sem_post(&LinuxContext->Queues.DispatchSem);
+  }
+}
+
+function memory_operation*
+ReceiveWorkResult(context* Context) {
+  linux_context* LinuxContext = (linux_context*)Context;
+  work_node* Work = 0;
+  while (!Work) {
+    sem_wait(&LinuxContext->Queues.ResultSem);
+    Work = DequeueWork(&LinuxContext->Queues.ResultHead);
+  }
+
+  memory_operation* Result = Work->Op;
+  FREE_LIST_FREE(LinuxContext->Queues.FirstFree, Work);
+
+  return Result;
+}
+
+function u32
+StringfConvert(char* Buffer, char const* Format, va_list Args) {
+  char ConvertedFormat[2048];
+  u32 NextSourceIndex = 0;
+  u32 NextDestIndex = 0;
+  u32 Index = 0;
+  // NOTE(btolsch): On x64, %Iu converts to %lu and %lu/%u both convert to %u.
+  while (Format[Index]) {
+    if (Format[Index++] == '%') {
+      b32 Searching = 1;
+      while (*Format && Searching) {
+        char c = Format[Index++];
+        switch (c) {
+          case '%':
+          case 'c':
+          case 'C':
+          case 'd':
+          case 's':
+          case 'S':
+          case 'u':
+          case 'i':
+          case 'x':
+          case 'X':
+          case 'p': Searching = 0; break;
+          case 'l': {
+            u32 CopySize = Index - NextSourceIndex - 1;
+            memcpy(ConvertedFormat + NextDestIndex, Format + NextSourceIndex, CopySize);
+            NextSourceIndex = Index;
+            NextDestIndex += CopySize;
+            Searching = 0;
+          } break;
+          case 'I': {
+            u32 CopySize = Index - NextSourceIndex - 1;
+            memcpy(ConvertedFormat + NextDestIndex, Format + NextSourceIndex, CopySize);
+            NextDestIndex += CopySize;
+            NextSourceIndex = Index;
+            ConvertedFormat[NextDestIndex++] = 'l';
+            Searching = 0;
+          } break;
+          default: break;
+        }
+      }
+      if (Searching) {
+        exit(1);
+      }
+    }
+  }
+
+  u32 CopySize = Index - NextSourceIndex;
+  memcpy(ConvertedFormat + NextDestIndex, Format + NextSourceIndex, CopySize);
+  ConvertedFormat[Index] = 0;
+
+  u32 Length = vsprintf(Buffer, ConvertedFormat, Args);
+
+  return Length;
+}
+
+function void
+Statusf(char const* Format, ...) {
+  char Buffer[2048];
+
+  va_list Args;
+  va_start(Args, Format);
+  u32 Length = StringfConvert(Buffer, Format, Args);
+  va_end(Args);
+
+  write(STDERR_FILENO, Buffer, Length);
+}
+
+function void
+Dataf(char const* Format, ...) {
+  char Buffer[2048];
+
+  va_list Args;
+  va_start(Args, Format);
+  u32 Length = StringfConvert(Buffer, Format, Args);
+  va_end(Args);
+
+  write(STDOUT_FILENO, Buffer, Length);
+}
+
+function u32
+Stringf(char* Buffer, char const* Format, ...) {
+  va_list Args;
+  va_start(Args, Format);
+  u32 Length = StringfConvert(Buffer, Format, Args);
+  va_end(Args);
+  return Length;
+}
+
+function void*
+AllocateAndClear(u64 Size) {
+  void* Result = mmap(0, Size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (Result == MAP_FAILED) {
+    Statusf("ERROR: Unable to allocate required memory.\n");
+    exit(1);
+  }
+  return Result;
+}
+
+function int
+ThreadEntryPoint(void* Arg) {
+  linux_context* LinuxContext = (linux_context*)Arg;
+  while (1) {
+    sem_wait(&LinuxContext->Queues.DispatchSem);
+    work_node* Work = DequeueWork(&LinuxContext->Queues.DispatchHead);
+    if (Work) {
+      memory_operation* Op = Work->Op;
+      do {
+        TIME_OPEN(Op->StartStamp);
+      } while (Op->StartStamp.Counter < Op->StartGateCounter);
+
+      Op->Handler(Op);
+      TIME_CLOSE(Op->EndStamp);
+
+      EnqueueWork(&LinuxContext->Queues.ResultHead, Work);
+      sem_post(&LinuxContext->Queues.ResultSem);
+    }
+  }
+  return 0;
+}
+
+int
+main(int argc, char** argv) {
+  // NOTE(btolsch): Initialize test setup based on CPU parameters.
+  timestamp BaseHz = {.Counter = 1000000000ull};
+
+  timestamp SleepBegin;
+  TIME_OPEN(SleepBegin);
+  usleep(1000000);
+  timestamp SleepEnd;
+  TIME_CLOSE(SleepEnd);
+
+  timestamp Delta = Subtract(SleepEnd, SleepBegin);
+  BaseHz.Clock = (Delta.Clock * BaseHz.Counter) / Delta.Counter;
+
+  int CID[4] = {0};
+  char CPUBrand[64] = {0};
+  __cpuid(0x80000002, ((int*)CPUBrand)[0], ((int*)CPUBrand)[1], ((int*)CPUBrand)[2],
+          ((int*)CPUBrand)[3]);
+  __cpuid(0x80000003, ((int*)CPUBrand)[4], ((int*)CPUBrand)[5], ((int*)CPUBrand)[6],
+          ((int*)CPUBrand)[7]);
+  __cpuid(0x80000004, ((int*)CPUBrand)[8], ((int*)CPUBrand)[9], ((int*)CPUBrand)[10],
+          ((int*)CPUBrand)[11]);
+
+  u32 MaxThreadCount = get_nprocs();
+
+  handler_table_entry MemoryHandlers[] = {
+      HANDLER_ENTRY(X64Read128), HANDLER_ENTRY(X64Write128), HANDLER_ENTRY(X64ReadWrite128),
+      HANDLER_ENTRY(X64Read256), HANDLER_ENTRY(X64Write256), HANDLER_ENTRY(X64ReadWrite256),
+      HANDLER_ENTRY(X64Read512), HANDLER_ENTRY(X64Write512), HANDLER_ENTRY(X64ReadWrite512),
+  };
+
+  // NOTE(btolsch): Assume SSE for x64, then determine AVX and AVX512 support.
+  u32 HandlerCount = 3;
+  __cpuid(1, CID[0], CID[1], CID[2], CID[3]);
+  if ((CID[2] & (1 << 28))) {
+    HandlerCount = 6;
+    __cpuid(7, CID[0], CID[1], CID[2], CID[3]);
+    if ((CID[1] & (1 << 16))) {
+      HandlerCount = 9;
+    }
+  }
+
+  // NOTE(btolsch): Prepare threads.
+  linux_context LinuxContext = {};
+  LinuxContext.Context.BaseHz = BaseHz;
+  LinuxContext.Context.MaxThreadCount = MaxThreadCount;
+  LinuxContext.Context.HandlerCount = HandlerCount;
+  LinuxContext.Context.Handlers = MemoryHandlers;
+  LinuxContext.Context.CPUBrand = CPUBrand;
+  LinuxContext.Context.LogicalCoreCount = MaxThreadCount;
+
+  {
+    sem_init(&LinuxContext.Queues.DispatchSem, 0, 0);
+    sem_init(&LinuxContext.Queues.ResultSem, 0, 0);
+
+    u32 TotalWorkCount = 4 * MaxThreadCount;
+    u32 TotalWorkSize = sizeof(work_node) * TotalWorkCount;
+    work_node* Nodes = (work_node*)AllocateAndClear(TotalWorkSize);
+    for (u32 WorkIndex = 0; WorkIndex < TotalWorkCount; ++WorkIndex) {
+      FREE_LIST_FREE(LinuxContext.Queues.FirstFree, Nodes + WorkIndex);
+    }
+  }
+
+  u32 StackSize = 1024 * 1024;  // NOTE(btolsch): Mostly chosen for parity with win32 platform.
+  u32 CloneFlags = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SYSVSEM | CLONE_SIGHAND | CLONE_THREAD;
+  for (u32 ThreadIndex = 0; ThreadIndex < MaxThreadCount; ++ThreadIndex) {
+    void* Stack = AllocateAndClear(StackSize);
+    int Result = clone(&ThreadEntryPoint, (u8*)Stack + StackSize, CloneFlags, &LinuxContext);
+    if (Result < 0) {
+      Statusf("Unable to start thread.\n");
+      exit(1);
+    }
+  }
+
+  // NOTE(btolsch): Run tests.
+  Main(&LinuxContext.Context);
+
+  exit(0);
+}

--- a/linux_build.sh
+++ b/linux_build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+CFLAGS_C="-Wall -Werror -Wno-unused-function -Wno-unused-variable -march=native -pthread"
+
+mkdir -p build
+pushd build
+
+echo "-----------------"
+echo "Building debug..."
+clang $CFLAGS_C -O0 -g ../linux_blandwidth.c -o blandwidth_debug
+
+echo "-----------------"
+echo "Building release..."
+clang $CFLAGS_C -O3 -g ../linux_blandwidth.c -o blandwidth_release
+
+echo "-----------------"
+echo "Generating analysis..."
+clang -O3 -DLLVM_MCA=1 $CFLAGS_C ../linux_blandwidth.c -mllvm -x86-asm-syntax=intel -S -o blandwidth_release.asm
+llvm-mca blandwidth_release.asm > blandwidth_release.mca
+
+popd

--- a/win32_blandwidth.c
+++ b/win32_blandwidth.c
@@ -88,6 +88,16 @@ Dataf(char const *Format, ...)
     WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), Buffer, Length, &Ignored, 0);
 }
 
+function u32
+Stringf(char *Buffer, char const *Format, ...)
+{
+    va_list Args;
+    va_start(Args, Format);
+    u32 Length = wvsprintf(Buffer, Format, Args);
+    va_end(Args);
+    return Length;
+}
+
 function void *
 AllocateAndClear(u64 Size)
 {
@@ -140,17 +150,17 @@ mainCRTStartup(void)
     // NOTE(casey): Determine base timer and CPU frequencies
     //
     
-    time BaseHz;
+    timestamp BaseHz;
     QueryPerformanceFrequency((LARGE_INTEGER *)&BaseHz.Counter);
     BaseHz.Clock = 0;
     
-    time SleepBegin;
+    timestamp SleepBegin;
     TIME_OPEN(SleepBegin);
     Sleep(1000);
-    time SleepEnd;
+    timestamp SleepEnd;
     TIME_CLOSE(SleepEnd);
     
-    time Delta = Subtract(SleepEnd, SleepBegin);
+    timestamp Delta = Subtract(SleepEnd, SleepBegin);
     BaseHz.Clock = (Delta.Clock * BaseHz.Counter) / Delta.Counter;
     
     //


### PR DESCRIPTION
I hope you find this helpful; if not, feel free to close this.

First of all, I did compile this with both MSVC and clang on Windows.  I also got roughly the same numbers on both Linux and Windows (though I didn't take any statistics, measure whether there was a difference in the gate operation, etc.).  So that's something.

There were two changes I had to make to the main code to get this to work on Linux (the format strings are a separate issue).  There was one direct usage of `wsprintf` in blandwidth.c, so I added a platform function `Stringf` to do that.  I also had to rename `struct time` because it collides with the Linux definition.

I wrote a conversion function to go from `wsprintf` format strings to Linux `sprintf` strings (just the 64-bit int issue).  The other alternative I could see is using macros like so:
```
// Win32
#define FMTu64 "%Iu"
// Linux
#define FMTu64 "%lu"

Statusf(Buffer, "Label: " FMTu64 "," FMTu64 "\n", ...);
```
That makes the format strings slightly harder to read though, so that wasn't really my first choice in this case.

There are also fixes for #11 and the clang `CTAssert` TODO in here if you don't get to them first.

Lastly, I didn't try to emulate your braces/spacing yet.  I can take a shot at cleaning that up if you want to merge this.